### PR TITLE
Fix HTML escaping for note rendering

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -194,7 +194,16 @@ document.getElementById('dlPngBtn').onclick = () => {
 
 // Notes utilities
 function lsKey(pathStr){ return 'thb_notes::' + pathStr; }
-function escapeHtml(s){ return s.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',''':'&#39;'}[m])); }
+const HTML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+};
+function escapeHtml(s){
+  return String(s ?? '').replace(/[&<>"']/g, m => HTML_ESCAPES[m]);
+}
 function loadNotes(pathStr){
   const el = document.getElementById('notesList');
   el.innerHTML = '';


### PR DESCRIPTION
## Summary
- replace the broken notes HTML escaping helper with a safe implementation that handles quotes and nullish values

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68dd6e18a2bc8329aad0ec0e69165f64