### PR TITLE
Refine budget drilldown view and note styling

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -74,7 +74,7 @@ function render(root, pathArr){
       edgeShape: 'curve',
       layout: 'radial',
       roam: true,
-      initialTreeDepth: 2,
+      initialTreeDepth: 1,
       animationDurationUpdate: 400,
       lineStyle: { color: 'rgba(148, 163, 184, 0.28)' },
       itemStyle: {
@@ -204,6 +204,15 @@ const HTML_ESCAPES = {
 function escapeHtml(s){
   return String(s ?? '').replace(/[&<>"']/g, m => HTML_ESCAPES[m]);
 }
+function formatNoteWords(text){
+  const words = String(text || '')
+    .split(/\s+/)
+    .map(w => w.trim())
+    .filter(Boolean);
+  if (!words.length) return '<span class="note-word">—</span>';
+  return words.map(word => `<span class="note-word">${escapeHtml(word)}</span>`).join('');
+}
+
 function loadNotes(pathStr){
   const el = document.getElementById('notesList');
   el.innerHTML = '';
@@ -216,7 +225,7 @@ function loadNotes(pathStr){
   for (const n of notes){
     const div = document.createElement('div');
     div.className = 'note';
-    div.innerHTML = `${escapeHtml(n.text)}<time>${new Date(n.ts).toLocaleString()}</time>`;
+    div.innerHTML = `<div class="note-words">${formatNoteWords(n.text)}</div><time>${new Date(n.ts).toLocaleString()}</time>`;
     el.appendChild(div);
   }
 }

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -279,6 +279,26 @@ body {
   box-shadow: 0 10px 24px rgba(2, 6, 23, 0.35);
 }
 
+.note-words {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.note-word {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 8px;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.55);
+  color: #e0f2fe;
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+}
+
 .note time {
   display: block;
   color: #93c5fd;


### PR DESCRIPTION
## Summary
- limit the initial tree depth so the chart starts at the Thailand budget level and drills into ministries on click
- render saved notes as word tokens so each word is boxed for emphasis
- style the new note word tokens to match the existing sidebar theme

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68dd6fc40abc832995a0a3b07953cd71