### PR TITLE
Fix chart rendering by cleaning merge conflict markers

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -80,8 +80,7 @@ function render(root, pathArr, depthOverride){
 
       expandAndCollapse: false,
       initialTreeDepth: depth,
-=======
-     main
+      animationDuration: 450,
       animationDurationUpdate: 400,
       lineStyle: { color: 'rgba(148, 163, 184, 0.28)' },
       itemStyle: {


### PR DESCRIPTION
## Summary
- remove leftover merge conflict markers from the tree chart configuration
- restore animation settings so the ECharts radial tree initializes correctly

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de01bdddac8329bb4e44a93942511a