### PR TITLE
Improve mind map focus and sidebar usability

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -19,6 +19,25 @@ const THB = n => new Intl.NumberFormat('en-US').format(n);
 const compactTHB = n => '฿' + new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 2 }).format(n);
 const pct = (num, den) => (den && num != null) ? ((num/den)*100).toFixed(2) + '%' : '—';
 
+const descEl = document.getElementById('nodeDesc');
+const descToggleBtn = document.getElementById('toggleDesc');
+let isDescOpen = true;
+
+function setDescOpen(open){
+  isDescOpen = open;
+  if (descToggleBtn){
+    descToggleBtn.textContent = open ? 'Hide' : 'Show';
+    descToggleBtn.setAttribute('aria-expanded', String(open));
+  }
+  if (descEl){
+    descEl.classList.toggle('open', open);
+  }
+}
+
+if (descToggleBtn){
+  descToggleBtn.addEventListener('click', () => setDescOpen(!isDescOpen));
+}
+
 function sanitize(node){
   // Coerce value to number, allow desc, ensure children array
   const v = node.value;
@@ -78,7 +97,7 @@ function render(root, pathArr, depthOverride){
       layout: 'radial',
       roam: true,
 
-      expandAndCollapse: false,
+      expandAndCollapse: true,
       initialTreeDepth: depth,
       animationDuration: 450,
       animationDurationUpdate: 400,
@@ -117,6 +136,7 @@ function render(root, pathArr, depthOverride){
       emphasis: { focus: 'descendant' }
     }]
   });
+  chart.resize();
   updateDetails(root, currentPath, total, null);
   document.getElementById('backBtn').disabled = stack.length === 0;
 }
@@ -156,6 +176,7 @@ function updateSummaryCards(root){
 function applyData(data){
   originalData = sanitize(data);
   stack.length = 0;
+  setDescOpen(true);
   render(originalData, [originalData.name], 1);
   updateSummaryCards(originalData);
 }
@@ -167,7 +188,8 @@ function updateDetails(node, pathArr, total, parentTotal){
   document.getElementById('nodeTotal').textContent = nodeTotal != null ? '฿' + THB(nodeTotal) : '—';
   document.getElementById('nodeShare').textContent = parentTotal ? pct(nodeTotal, parentTotal) : '—';
   document.getElementById('nodePath').textContent = pathStr;
-  document.getElementById('nodeDesc').textContent = node.desc || '—';
+  if (descEl){ descEl.textContent = node.desc || '—'; }
+  setDescOpen(isDescOpen);
 
   loadNotes(pathStr);
   document.getElementById('addNoteBtn').onclick = () => addNote(pathStr);

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -186,18 +186,18 @@ body {
 
 .layout {
   flex: 1;
-  width: min(1240px, calc(100% - 48px));
+  width: min(1360px, calc(100% - 48px));
   margin: 0 auto 36px;
   display: grid;
   gap: 20px;
-  grid-template-columns: minmax(0, 1fr) 360px;
+  grid-template-columns: minmax(0, 1fr) 320px;
   align-items: stretch;
 }
 
 #chart {
   width: 100%;
-  height: 70vh;
-  min-height: 520px;
+  height: 78vh;
+  min-height: 640px;
   background: rgba(15, 23, 42, 0.55);
   border: 1px solid rgba(148, 163, 184, 0.18);
   border-radius: 28px;
@@ -212,8 +212,8 @@ body {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  height: 70vh;
-  min-height: 520px;
+  height: 78vh;
+  min-height: 640px;
   overflow-y: auto;
   box-shadow: 0 18px 48px rgba(8, 11, 24, 0.45);
 }
@@ -243,6 +243,39 @@ body {
   line-height: 1.6;
   margin: 6px 0 10px;
   white-space: pre-wrap;
+}
+
+.collapsible-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.collapse-toggle {
+  border: none;
+  background: rgba(56, 189, 248, 0.14);
+  color: #bae6fd;
+  border-radius: 999px;
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: transform 0.18s ease, opacity 0.18s ease;
+}
+
+.collapse-toggle:hover {
+  transform: translateY(-1px);
+}
+
+.collapsible-body {
+  display: none;
+}
+
+.collapsible-body.open {
+  display: block;
 }
 
 .notesHeader {
@@ -289,49 +322,12 @@ body {
 .note-word {
   display: inline-flex;
   align-items: center;
-// choose a safe initial depth (use 1 if depth is undefined/null/not a number)
-const initialDepth = Number.isFinite?.(depth) ? depth : (Number.isFinite(depth) ? depth : 1);
-
-option = {
-  // ...
-  series: [{
-    type: 'tree',
-    // keep nodes expanded to show ministry box by default
-    expandAndCollapse: false,
-    initialTreeDepth: initialDepth, // dynamic, with fallback
-    animationDurationUpdate: 400,
-    lineStyle: { color: 'rgba(148, 163, 184, 0.28)' },
-    itemStyle: {
-      color: '#38bdf8',
-      borderColor: 'rgba(148,163,184,0.35)',
-      borderWidth: 1.2
-    },
-    label: {
-      position: 'top',
-      verticalAlign: 'middle',
-      align: 'center',
-      rotate: 'radial',
-      distance: 12,
-      color: '#f1f5f9',
-      fontSize: 12,
-      formatter: function (params) {
-        const n = params.data;
-        // guard ancestors & root
-        const ancestors = (params.treeAncestors && params.treeAncestors.length > 0)
-          ? params.treeAncestors
-          : [];
-        const parent = ancestors.length > 1 ? ancestors[1] : (typeof root !== 'undefined' ? root : n);
-        const pv = computeTotal(n) || 0;
-        const pTotal = computeTotal(parent) || pv || 1;
-        const share = pct(pv, pTotal);
-        return n.name + (pv ? '\n' + compactTHB(pv) + ' (' + share + ')' : '');
-      }
-    }
-    // ... any other series options
-  }]
-  // ... any other top-level options
-};
-
+  padding: 4px 8px;
+  border-radius: 999px;
+  background: rgba(56, 189, 248, 0.22);
+  color: #e0f2fe;
+  font-weight: 600;
+  font-size: 12px;
 }
 
 .note time {

--- a/index.html
+++ b/index.html
@@ -65,8 +65,11 @@
         </div>
         <div class="divider"></div>
         <div>
-          <div class="stat"><span class="k">Description</span></div>
-          <div class="desc" id="nodeDesc">Add optional "desc" in your JSON to show details for this ministry.</div>
+          <div class="stat collapsible-header">
+            <span class="k">Description</span>
+            <button type="button" class="collapse-toggle" id="toggleDesc" aria-expanded="true">Hide</button>
+          </div>
+          <div class="desc collapsible-body open" id="nodeDesc">Add optional "desc" in your JSON to show details for this ministry.</div>
         </div>
         <div class="divider"></div>
         <div class="notesHeader">


### PR DESCRIPTION
## Summary
- collapse deeper budget branches by default so only ministries appear initially, while keeping drilldowns available on click
- enlarge the mind map canvas and rebalance the layout to give the visualization more room
- add a collapsible description section in the sidebar for optional details

## Testing
- Manual: `python -m http.server 8000` (viewed in browser)


------
https://chatgpt.com/codex/tasks/task_e_68de94471fd883298f505ec5e094ea5e