### PR TITLE
Improve budget center badge and ministry detail interactions

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -194,6 +194,7 @@ body {
   color: #f8fafc;
   text-align: center;
   text-shadow: 0 10px 24px rgba(15, 23, 42, 0.55);
+  white-space: pre-line;
 }
 
 .center-sub {


### PR DESCRIPTION
## Summary
- update the center badge to reflect the selected node with total allocation information
- sort ministry departments by budget and surface totals in the side panel
- allow multiline center labels so the Thailand budget title stays centered

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deacb6318c8329b872eb424995085b