### PR TITLE
Build interactive mindmap navigation for Thailand budget

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,5 +1,8 @@
 const chart = echarts.init(document.getElementById('chart'));
 let dataset = null;
+let currentCenter = null;
+let nodeCounter = 0;
+const nodeIndex = new Map();
 
 const els = {
   total: document.getElementById('totalBudget'),
@@ -15,8 +18,11 @@ const els = {
   desc: document.getElementById('nodeDesc'),
   children: document.getElementById('childrenList'),
   centerTitle: document.getElementById('mindmapTitle'),
-  centerSubtitle: document.getElementById('mindmapSubtitle')
+  centerSubtitle: document.getElementById('mindmapSubtitle'),
+  back: document.getElementById('backBtn')
 };
+
+const palette = ['#38bdf8', '#f472b6', '#facc15', '#34d399', '#a855f7', '#fb7185', '#22d3ee'];
 
 const THB = (value) => new Intl.NumberFormat('en-US').format(value);
 const compactTHB = (value) =>
@@ -28,12 +34,40 @@ const compactTHB = (value) =>
 const pct = (value, total) =>
   total && value != null ? ((value / total) * 100).toFixed(2) + '%' : '—';
 
-function sanitize(node) {
-  const copy = { ...node };
-  copy.value = node.value == null || node.value === '' ? null : Number(node.value);
-  copy.desc = node.desc || '';
-  copy.children = Array.isArray(node.children) ? node.children.map(sanitize) : [];
-  copy.meta = node.meta;
+function parseBudgetValue(value) {
+  if (value == null || value === '') return null;
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const normalized = value.replace(/[฿,\s]/g, '').toUpperCase();
+    const match = normalized.match(/^([0-9]*\.?[0-9]+)([KMBT]?)$/);
+    if (match) {
+      const amount = parseFloat(match[1]);
+      const unit = match[2];
+      const multipliers = { K: 1e3, M: 1e6, B: 1e9, T: 1e12 };
+      return amount * (multipliers[unit] || 1);
+    }
+    const numeric = Number(normalized);
+    return Number.isNaN(numeric) ? null : numeric;
+  }
+  return null;
+}
+
+function sanitize(node, parent = null) {
+  const copy = {
+    id: ++nodeCounter,
+    name: node.name || 'Untitled node',
+    value: parseBudgetValue(node.value),
+    rawValue: node.value,
+    desc: node.desc || ''
+  };
+  if (node.meta) {
+    copy.meta = node.meta;
+  }
+  nodeIndex.set(copy.id, copy);
+  copy.children = Array.isArray(node.children)
+    ? node.children.map((child) => sanitize(child, copy))
+    : [];
+  Object.defineProperty(copy, '__parent', { value: parent, enumerable: false });
   return copy;
 }
 
@@ -44,6 +78,26 @@ function sumChildren(node) {
 
 function totalFor(node) {
   return node.value != null ? node.value : sumChildren(node);
+}
+
+function countLeaves(node) {
+  if (!node.children || !node.children.length) return 1;
+  return node.children.reduce((total, child) => total + countLeaves(child), 0);
+}
+
+function buildPath(node) {
+  const steps = [];
+  let current = node;
+  while (current) {
+    steps.unshift(current.name);
+    current = current.__parent || null;
+  }
+  return steps;
+}
+
+function formatTitle(name) {
+  if (!name) return 'Thailand Budget';
+  return name.replace(/\s*\(/, '\n(');
 }
 
 function hexToRgb(hex) {
@@ -64,96 +118,8 @@ function withAlpha(hex, alpha) {
   return `rgba(${r}, ${g}, ${b}, ${alpha})`;
 }
 
-function decorateMindmap(root) {
-  if (!root) return root;
-  const palette = ['#f97316', '#22c55e', '#3b82f6', '#a855f7', '#ec4899', '#14b8a6'];
-  root.symbolSize = 120;
-  root.itemStyle = {
-    color: '#0f172a',
-    borderColor: '#1f2937',
-    borderWidth: 10,
-    shadowBlur: 45,
-    shadowColor: 'rgba(15, 23, 42, 0.45)'
-  };
-  root.label = {
-    show: false,
-    color: '#f8fafc',
-    fontSize: 22,
-    fontWeight: 700,
-    padding: [14, 24],
-    backgroundColor: '#0f172a',
-    borderRadius: 999,
-    borderWidth: 0,
-    align: 'center',
-    verticalAlign: 'middle',
-    shadowBlur: 0
-  };
-
-  if (!Array.isArray(root.children)) return root;
-
-  root.children.forEach((child, index) => {
-    const color = palette[index % palette.length];
-    decorateBranch(child, 1, color);
-  });
-  return root;
-}
-
-function decorateBranch(node, depth, branchColor) {
-  const symbolSize = depth === 1 ? 70 : Math.max(32, 64 - depth * 6);
-  const mainColor = withAlpha(branchColor, 1);
-  const borderColor = depth === 1 ? mainColor : withAlpha(branchColor, 0.85);
-  const lineColor = withAlpha(branchColor, depth === 1 ? 0.85 : 0.55);
-  const bubbleFill = depth === 1 ? '#ffffff' : withAlpha(branchColor, 0.12);
-  node.symbolSize = symbolSize;
-  node.itemStyle = {
-    color: bubbleFill,
-    borderColor,
-    borderWidth: depth === 1 ? 6 : 3,
-    shadowBlur: depth === 1 ? 30 : 18,
-    shadowColor: withAlpha(branchColor, depth === 1 ? 0.4 : 0.25)
-  };
-  node.lineStyle = {
-    color: lineColor,
-    width: depth === 1 ? 5 : 3,
-    curveness: 0.55
-  };
-  node.label = {
-    color: '#0f172a',
-    fontWeight: depth <= 2 ? 600 : 500,
-    fontSize: depth === 1 ? 16 : 14,
-    backgroundColor: '#ffffff',
-    borderColor: withAlpha(branchColor, 0.45),
-    borderWidth: 1.5,
-    borderRadius: 22,
-    padding: [8, 18],
-    shadowBlur: 14,
-    shadowColor: withAlpha(branchColor, 0.18),
-    position: 'top',
-    distance: depth === 1 ? 28 : 18,
-    align: 'center',
-    verticalAlign: 'middle',
-    rotate: 'radial'
-  };
-  node.emphasis = {
-    label: {
-      backgroundColor: '#f1f5f9',
-      borderColor: withAlpha(branchColor, 0.65),
-      borderWidth: 2,
-      color: '#0f172a'
-    }
-  };
-
-  if (Array.isArray(node.children)) {
-    node.children.forEach((child) => decorateBranch(child, depth + 1, branchColor));
-  }
-}
-
-function countLeaves(node) {
-  if (!node.children || !node.children.length) return 1;
-  return node.children.reduce((total, child) => total + countLeaves(child), 0);
-}
-
 function updateSummary(root) {
+  if (!root) return;
   const total = totalFor(root);
   const ministries = Array.isArray(root.children) ? root.children.length : 0;
   let programs = 0;
@@ -180,77 +146,34 @@ function updateSummary(root) {
   if (els.fiscal) els.fiscal.textContent = meta.fiscalYear || 'FY';
 }
 
-function renderChart(root) {
-  chart.setOption({
-    backgroundColor: 'rgba(0,0,0,0)',
-    tooltip: {
-      trigger: 'item',
-      triggerOn: 'mousemove',
-      backgroundColor: 'rgba(15, 23, 42, 0.92)',
-      borderColor: 'rgba(255, 255, 255, 0.35)',
-      borderWidth: 1,
-      textStyle: { color: '#f8fafc', fontSize: 12 },
-      formatter: (params) => {
-        const node = params.data;
-        const path = (params.treePathInfo || []).map((step) => step.name).join(' / ');
-        const total = totalFor(node);
-        let parentTotal = null;
-        if (params.treeAncestors && params.treeAncestors.length > 1) {
-          parentTotal = totalFor(params.treeAncestors[1]);
-        }
-        const lines = [
-          `<div style="font-weight:600;margin-bottom:4px;">${path}</div>`,
-          `<div>${total != null ? '฿' + THB(total) : 'Not specified'}</div>`
-        ];
-        if (parentTotal != null) {
-          lines.push(`<div style="opacity:0.7;font-size:11px;">Share of parent: ${pct(total, parentTotal)}</div>`);
-        }
-        return lines.join('');
+function updateBackButton() {
+  if (!els.back) return;
+  if (!dataset || currentCenter === dataset) {
+    els.back.classList.add('hidden');
+  } else {
+    els.back.classList.remove('hidden');
+  }
+}
+
+function updateCenterBadge(node, parent) {
+  if (!node) return;
+  const total = totalFor(node);
+  const parentTotal = parent ? totalFor(parent) : null;
+  if (els.centerTitle) {
+    els.centerTitle.textContent = formatTitle(node.name);
+  }
+  if (els.centerSubtitle) {
+    if (total != null) {
+      let subtitle = compactTHB(total);
+      const share = pct(total, parentTotal);
+      if (parent && share !== '—') {
+        subtitle += ` · ${share} of ${parent.name}`;
       }
-    },
-    series: [
-      {
-        type: 'tree',
-        data: [root],
-        layout: 'radial',
-        orient: 'LR',
-        top: '6%',
-        bottom: '6%',
-        left: '6%',
-        right: '6%',
-        symbol: 'circle',
-        roam: true,
-        expandAndCollapse: false,
-        initialTreeDepth: 2,
-        animationDuration: 600,
-        animationDurationUpdate: 450,
-        lineStyle: {
-          color: 'rgba(148, 163, 184, 0.45)',
-          width: 2,
-          curveness: 0.5
-        },
-        label: {
-          formatter: (params) => {
-            if (!params.treeAncestors || params.treeAncestors.length <= 1) {
-              return '';
-            }
-            const node = params.data;
-            const value = totalFor(node);
-            const share = params.treeAncestors.length > 1
-              ? pct(value, totalFor(params.treeAncestors[1]))
-              : '—';
-            return value != null
-              ? `${node.name}\n${compactTHB(value)}${share !== '—' ? ` (${share})` : ''}`
-              : node.name;
-          }
-        },
-        emphasis: {
-          focus: 'ancestor'
-        }
-      }
-    ]
-  });
-  chart.resize();
+      els.centerSubtitle.textContent = subtitle;
+    } else {
+      els.centerSubtitle.textContent = 'Total allocation not specified';
+    }
+  }
 }
 
 function renderChildren(node) {
@@ -264,7 +187,8 @@ function renderChildren(node) {
     return;
   }
   const parentTotal = totalFor(node);
-  for (const child of node.children) {
+  const sortedChildren = [...node.children].sort((a, b) => totalFor(b) - totalFor(a));
+  for (const child of sortedChildren) {
     const item = document.createElement('li');
     const name = document.createElement('span');
     name.className = 'name';
@@ -273,9 +197,9 @@ function renderChildren(node) {
     amount.className = 'amount';
     const value = totalFor(child);
     const share = pct(value, parentTotal);
-    amount.textContent = share === '—'
-      ? (value != null ? '฿' + THB(value) : '—')
-      : `${value != null ? '฿' + THB(value) : '—'} · ${share}`;
+    amount.textContent = value != null
+      ? `฿${THB(value)}${share !== '—' ? ` · ${share}` : ''}`
+      : '—';
     item.append(name, amount);
     els.children.appendChild(item);
   }
@@ -286,50 +210,315 @@ function showNodeDetails(node, path, parent) {
   const total = totalFor(node);
   const parentTotal = parent ? totalFor(parent) : null;
   if (els.title) els.title.textContent = node.name;
-  if (els.totalDetail) els.totalDetail.textContent = total != null ? '฿' + THB(total) : '—';
-  if (els.share) els.share.textContent = pct(total, parentTotal);
-  if (els.path) els.path.textContent = '/' + path.join('/');
+  if (els.totalDetail) {
+    els.totalDetail.textContent = total != null ? '฿' + THB(total) : '—';
+  }
+  if (els.share) {
+    els.share.textContent = pct(total, parentTotal);
+  }
+  if (els.path) {
+    els.path.textContent = '/' + path.join('/');
+  }
   if (els.desc) {
-    els.desc.textContent = node.desc ? node.desc : 'No additional description provided for this node.';
+    els.desc.textContent = node.desc
+      ? node.desc
+      : 'No additional description provided for this node.';
   }
   renderChildren(node);
 }
 
-function applyData(data) {
-  dataset = decorateMindmap(sanitize(data));
-  updateSummary(dataset);
-  renderChart(dataset);
-  showNodeDetails(dataset, [dataset.name], null);
-  const total = totalFor(dataset);
-  if (els.centerTitle) els.centerTitle.textContent = dataset.name || 'Thailand Budget';
-  if (els.centerSubtitle) {
-    els.centerSubtitle.textContent = total != null
-      ? `Total allocation ${compactTHB(total)}`
-      : 'Tap a branch to explore details';
+function cloneNodeForTree(node, depth, maxDepth) {
+  const clone = {
+    name: node.name,
+    nodeId: node.id,
+    total: totalFor(node)
+  };
+  if (depth < maxDepth && node.children && node.children.length) {
+    clone.children = node.children.map((child) => cloneNodeForTree(child, depth + 1, maxDepth));
+  } else {
+    clone.children = [];
+  }
+  return clone;
+}
+
+function createBreadcrumbNode(target) {
+  return {
+    name: `◀ ${target.name}`,
+    nodeId: target.id,
+    total: totalFor(target),
+    breadcrumb: true,
+    children: []
+  };
+}
+
+function decorateBreadcrumb(node) {
+  node.value = node.total;
+  node.symbolSize = 46;
+  node.itemStyle = {
+    color: 'rgba(15, 23, 42, 0.92)',
+    borderColor: 'rgba(148, 163, 184, 0.65)',
+    borderWidth: 2,
+    shadowBlur: 20,
+    shadowColor: 'rgba(15, 23, 42, 0.5)'
+  };
+  node.lineStyle = {
+    color: 'rgba(148, 163, 184, 0.55)',
+    width: 2,
+    curveness: 0.6
+  };
+  node.label = {
+    show: true,
+    fontSize: 12,
+    fontWeight: 600,
+    color: '#e2e8f0',
+    backgroundColor: 'rgba(15, 23, 42, 0.78)',
+    borderColor: 'rgba(148, 163, 184, 0.5)',
+    borderWidth: 1,
+    borderRadius: 16,
+    padding: [6, 16],
+    position: 'top',
+    distance: 18,
+    align: 'center',
+    verticalAlign: 'middle',
+    formatter: () => 'Back to ' + (nodeIndex.get(node.nodeId)?.name || 'overview')
+  };
+  node.emphasis = {
+    label: {
+      color: '#f8fafc',
+      backgroundColor: 'rgba(30, 41, 59, 0.92)'
+    }
+  };
+}
+
+function decorateBranch(node, depth, branchColor) {
+  node.value = node.total;
+  const symbolSize = depth === 1 ? 74 : Math.max(40, 74 - depth * 10);
+  const fill = depth === 1 ? withAlpha(branchColor, 0.12) : withAlpha(branchColor, 0.08);
+  const border = depth === 1 ? withAlpha(branchColor, 0.85) : withAlpha(branchColor, 0.6);
+  const line = withAlpha(branchColor, depth === 1 ? 0.65 : 0.45);
+  node.symbolSize = symbolSize;
+  node.itemStyle = {
+    color: fill,
+    borderColor: border,
+    borderWidth: depth === 1 ? 5 : 3,
+    shadowBlur: depth === 1 ? 32 : 20,
+    shadowColor: withAlpha(branchColor, depth === 1 ? 0.5 : 0.3)
+  };
+  node.lineStyle = {
+    color: line,
+    width: depth === 1 ? 4 : 2,
+    curveness: 0.55
+  };
+  node.label = {
+    show: true,
+    color: '#0f172a',
+    fontWeight: depth <= 2 ? 600 : 500,
+    fontSize: depth === 1 ? 15 : 13,
+    backgroundColor: 'rgba(248, 250, 252, 0.95)',
+    borderColor: withAlpha(branchColor, 0.45),
+    borderWidth: 1.4,
+    borderRadius: 18,
+    padding: [6, 16],
+    shadowBlur: 18,
+    shadowColor: withAlpha(branchColor, 0.25),
+    position: 'top',
+    distance: depth === 1 ? 26 : 18,
+    align: 'center',
+    verticalAlign: 'middle',
+    rotate: 'radial',
+    formatter: ({ data }) => {
+      const reference = nodeIndex.get(data.nodeId);
+      const labelName = reference ? reference.name : data.name;
+      const value = data.total;
+      if (value == null) return labelName;
+      const parent = reference?.__parent || null;
+      const share = parent ? pct(value, totalFor(parent)) : '—';
+      return share !== '—'
+        ? `${labelName}\n${compactTHB(value)} · ${share}`
+        : `${labelName}\n${compactTHB(value)}`;
+    }
+  };
+  node.emphasis = {
+    label: {
+      backgroundColor: '#f8fafc',
+      borderColor: withAlpha(branchColor, 0.65),
+      borderWidth: 2,
+      color: '#0f172a'
+    }
+  };
+  if (Array.isArray(node.children)) {
+    node.children.forEach((child) => decorateBranch(child, depth + 1, branchColor));
   }
 }
 
-chart.on('click', (params) => {
-  const node = params.data;
+function decorateMindmap(root) {
+  if (!root) return root;
+  root.value = root.total;
+  root.symbolSize = 150;
+  root.itemStyle = {
+    color: 'rgba(15, 23, 42, 0.98)',
+    borderColor: 'rgba(94, 234, 212, 0.35)',
+    borderWidth: 8,
+    shadowBlur: 55,
+    shadowColor: 'rgba(14, 165, 233, 0.45)'
+  };
+  root.label = {
+    show: true,
+    position: 'inside',
+    color: '#f8fafc',
+    fontSize: 20,
+    fontWeight: 700,
+    align: 'center',
+    verticalAlign: 'middle',
+    formatter: (params) => (params.data.total != null ? compactTHB(params.data.total) : '—')
+  };
+  root.emphasis = {
+    label: {
+      show: true,
+      fontSize: 22
+    }
+  };
+  if (!Array.isArray(root.children)) return root;
+  let branchIndex = 0;
+  root.children.forEach((child) => {
+    if (child.breadcrumb) {
+      decorateBreadcrumb(child);
+    } else {
+      const color = palette[branchIndex % palette.length];
+      branchIndex += 1;
+      decorateBranch(child, 1, color);
+    }
+  });
+  return root;
+}
+
+function buildMindmapTree(center) {
+  if (!center) return null;
+  const isNational = center === dataset;
+  const maxDepth = isNational ? 1 : 2;
+  const tree = cloneNodeForTree(center, 0, maxDepth);
+  if (center.__parent) {
+    tree.children.unshift(createBreadcrumbNode(center.__parent));
+  }
+  return decorateMindmap(tree);
+}
+
+function renderMindmap() {
+  if (!currentCenter) return;
+  const tree = buildMindmapTree(currentCenter);
+  if (!tree) return;
+  chart.setOption({
+    backgroundColor: 'rgba(0,0,0,0)',
+    tooltip: {
+      trigger: 'item',
+      triggerOn: 'mousemove',
+      backgroundColor: 'rgba(15, 23, 42, 0.94)',
+      borderColor: 'rgba(94, 234, 212, 0.35)',
+      borderWidth: 1,
+      textStyle: { color: '#f8fafc', fontSize: 12 },
+      formatter: (params) => {
+        const data = params.data;
+        const node = nodeIndex.get(data.nodeId);
+        if (!node) return params.name;
+        const total = totalFor(node);
+        if (data.breadcrumb) {
+          return [
+            `<div style="font-weight:600;margin-bottom:4px;">Back to ${node.name}</div>`,
+            `<div>${total != null ? '฿' + THB(total) : 'Budget not specified'}</div>`
+          ].join('');
+        }
+        const parent = node.__parent || null;
+        const lines = [
+          `<div style="font-weight:600;margin-bottom:4px;">${node.name}</div>`,
+          `<div>Budget: ${total != null ? '฿' + THB(total) : 'Not specified'}</div>`
+        ];
+        if (parent) {
+          const share = pct(total, totalFor(parent));
+          if (share !== '—') {
+            lines.push(`<div style="opacity:0.7;font-size:11px;">Share of parent: ${share}</div>`);
+          }
+        }
+        return lines.join('');
+      }
+    },
+    series: [
+      {
+        type: 'tree',
+        data: [tree],
+        layout: 'radial',
+        orient: 'LR',
+        top: '6%',
+        bottom: '6%',
+        left: '6%',
+        right: '6%',
+        symbol: 'circle',
+        roam: true,
+        expandAndCollapse: false,
+        initialTreeDepth: 2,
+        animationDuration: 620,
+        animationDurationUpdate: 520,
+        animationEasing: 'cubicOut',
+        animationEasingUpdate: 'cubicOut',
+        lineStyle: {
+          color: 'rgba(94, 234, 212, 0.14)',
+          width: 1.8,
+          curveness: 0.52
+        },
+        label: { show: false },
+        emphasis: { focus: 'ancestor' }
+      }
+    ]
+  }, true);
+  chart.resize();
+}
+
+function focusNode(node) {
   if (!node) return;
-  const path = (params.treePathInfo || []).map((step) => step.name);
-  const parent = params.treeAncestors && params.treeAncestors.length > 1 ? params.treeAncestors[1] : null;
-  showNodeDetails(node, path, parent);
+  currentCenter = node;
+  updateBackButton();
+  updateCenterBadge(node, node.__parent || null);
+  renderMindmap();
+  const path = buildPath(node);
+  showNodeDetails(node, path, node.__parent || null);
+}
+
+chart.on('click', (params) => {
+  const data = params.data;
+  if (!data) return;
+  const node = nodeIndex.get(data.nodeId);
+  if (!node) return;
+  if (data.breadcrumb) {
+    focusNode(node);
+    return;
+  }
+  if (node.children && node.children.length) {
+    focusNode(node);
+  } else {
+    const path = buildPath(node);
+    showNodeDetails(node, path, node.__parent || null);
+  }
 });
 
 document.getElementById('resetBtn').addEventListener('click', () => {
   if (!dataset) return;
-  chart.dispatchAction({ type: 'restore' });
-  showNodeDetails(dataset, [dataset.name], null);
+  focusNode(dataset);
 });
 
 document.getElementById('dlPngBtn').addEventListener('click', () => {
-  const url = chart.getDataURL({ pixelRatio: 2, backgroundColor: '#f8fafc' });
+  const url = chart.getDataURL({ pixelRatio: 2, backgroundColor: '#0f172a' });
   const a = document.createElement('a');
   a.href = url;
-  a.download = 'thailand-budget-network.png';
+  a.download = 'thailand-budget-mindmap.png';
   a.click();
 });
+
+if (els.back) {
+  els.back.addEventListener('click', () => {
+    if (dataset) {
+      focusNode(dataset);
+    }
+  });
+}
 
 const fileInput = document.getElementById('fileInput');
 fileInput.addEventListener('change', (event) => {
@@ -338,8 +527,13 @@ fileInput.addEventListener('change', (event) => {
   const reader = new FileReader();
   reader.onload = (e) => {
     try {
+      nodeCounter = 0;
+      nodeIndex.clear();
       const parsed = JSON.parse(e.target.result);
-      applyData(parsed);
+      dataset = sanitize(parsed, null);
+      currentCenter = dataset;
+      updateSummary(dataset);
+      focusNode(dataset);
     } catch (err) {
       alert('Invalid JSON: ' + err.message);
     }
@@ -351,10 +545,15 @@ async function loadDefault() {
   try {
     const response = await fetch('data/th_budget_FY2025.json', { cache: 'no-store' });
     const json = await response.json();
-    applyData(json);
+    nodeCounter = 0;
+    nodeIndex.clear();
+    dataset = sanitize(json, null);
+    currentCenter = dataset;
+    updateSummary(dataset);
+    focusNode(dataset);
   } catch (error) {
     console.warn('Failed to load default dataset, using fallback demo.', error);
-    applyData({
+    const fallback = {
       name: 'Thailand National Budget (Demo)',
       value: 3400000000000,
       meta: {
@@ -363,27 +562,53 @@ async function loadDefault() {
         source: 'Demo data generated in-app'
       },
       children: [
-        { name: 'Ministry of Finance', value: 840000000000, children: [
-          { name: 'Customs Department', value: 120000000000 },
-          { name: 'Excise Department', value: 150000000000 },
-          { name: 'Fiscal Policy Office', value: 90000000000 }
-        ]},
-        { name: 'Ministry of Education', value: 620000000000, children: [
-          { name: 'Office of the Basic Education Commission', value: 280000000000 },
-          { name: 'Office of the Vocational Education Commission', value: 120000000000 }
-        ]},
-        { name: 'Ministry of Public Health', value: 520000000000, children: [
-          { name: 'Department of Medical Services', value: 180000000000 },
-          { name: 'Department of Health', value: 96000000000 }
-        ]},
-        { name: 'Ministry of Transport', value: 410000000000, children: [
-          { name: 'Department of Highways', value: 160000000000 },
-          { name: 'State Railway of Thailand', value: 120000000000 }
-        ]},
+        {
+          name: 'Ministry of Finance',
+          value: 840000000000,
+          children: [
+            { name: 'Customs Department', value: 120000000000 },
+            { name: 'Excise Department', value: 150000000000 },
+            { name: 'Fiscal Policy Office', value: 90000000000 }
+          ]
+        },
+        {
+          name: 'Ministry of Education',
+          value: 620000000000,
+          children: [
+            { name: 'Office of the Basic Education Commission', value: 280000000000 },
+            { name: 'Vocational Education Commission', value: 120000000000 }
+          ]
+        },
+        {
+          name: 'Ministry of Public Health',
+          value: 520000000000,
+          children: [
+            { name: 'Department of Medical Services', value: 180000000000 },
+            { name: 'Department of Health', value: 96000000000 }
+          ]
+        },
+        {
+          name: 'Ministry of Transport',
+          value: 410000000000,
+          children: [
+            { name: 'Department of Highways', value: 160000000000 },
+            { name: 'State Railway of Thailand', value: 120000000000 }
+          ]
+        },
         { name: 'Central Fund (งบกลาง)', value: 420000000000 }
       ]
-    });
+    };
+    nodeCounter = 0;
+    nodeIndex.clear();
+    dataset = sanitize(fallback, null);
+    currentCenter = dataset;
+    updateSummary(dataset);
+    focusNode(dataset);
   }
 }
 
 loadDefault();
+
+window.addEventListener('resize', () => {
+  chart.resize();
+});

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,6 +1,7 @@
 :root {
-  color-scheme: light;
-  font-family: 'Inter', 'Noto Sans Thai', 'Sarabun', ui-sans-serif, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color-scheme: dark;
+  font-family: 'Inter', 'Noto Sans Thai', 'Sarabun', ui-sans-serif, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', sans-serif;
 }
 
 * {
@@ -14,33 +15,35 @@ body {
   align-items: center;
   justify-content: center;
   padding: 48px 24px;
-  background: radial-gradient(circle at 12% 18%, #fdf7ed 0%, #fefcf9 28%, #eef4ff 82%);
-  color: #0f172a;
+  background: radial-gradient(circle at 12% 18%, #0f172a, #020617 62%, #010314 100%);
+  color: #e2e8f0;
 }
 
 .canvas {
   position: relative;
-  width: 1980px;
-  height: 1080px;
-  padding: 54px 70px;
-  border-radius: 46px;
-  background: linear-gradient(155deg, rgba(255, 255, 255, 0.96), rgba(248, 250, 255, 0.9));
-  box-shadow: 0 48px 120px rgba(148, 163, 184, 0.28);
+  width: min(1840px, 100%);
+  min-height: 900px;
+  padding: 48px 64px 56px;
+  border-radius: 40px;
+  background: linear-gradient(140deg, rgba(15, 23, 42, 0.96), rgba(2, 6, 23, 0.94));
+  box-shadow: 0 48px 120px rgba(2, 6, 23, 0.68);
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  gap: 48px;
+  gap: 40px;
 }
 
 .canvas::before {
   content: '';
   position: absolute;
   inset: 24px;
-  border-radius: 36px;
+  border-radius: 32px;
   background:
-    radial-gradient(circle at 78% 16%, rgba(59, 130, 246, 0.18), transparent 52%),
-    radial-gradient(circle at 18% 82%, rgba(249, 115, 22, 0.16), transparent 58%),
-    radial-gradient(circle at 50% 50%, rgba(148, 163, 184, 0.12), transparent 70%);
+    radial-gradient(circle at 78% 22%, rgba(14, 165, 233, 0.22), transparent 60%),
+    radial-gradient(circle at 18% 80%, rgba(99, 102, 241, 0.2), transparent 62%),
+    radial-gradient(circle at 48% 52%, rgba(248, 113, 113, 0.18), transparent 72%);
+  opacity: 0.7;
+  filter: blur(0.5px);
   pointer-events: none;
   z-index: 1;
 }
@@ -55,7 +58,7 @@ body {
 
 .metrics {
   display: flex;
-  gap: 48px;
+  gap: 40px;
 }
 
 .metric {
@@ -65,16 +68,16 @@ body {
 }
 
 .metric-value {
-  font-size: 56px;
+  font-size: 52px;
   font-weight: 700;
-  letter-spacing: -0.02em;
-  color: #0f172a;
+  letter-spacing: -0.03em;
+  color: #f8fafc;
 }
 
 .metric-label {
-  font-size: 16px;
-  color: rgba(15, 23, 42, 0.55);
-  letter-spacing: 0.08em;
+  font-size: 15px;
+  color: rgba(148, 163, 184, 0.76);
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -82,25 +85,25 @@ body {
   display: grid;
   gap: 6px;
   text-align: right;
-  color: rgba(15, 23, 42, 0.75);
+  color: rgba(226, 232, 240, 0.8);
 }
 
 .meta-label {
-  font-size: 14px;
+  font-size: 13px;
   text-transform: uppercase;
-  letter-spacing: 0.18em;
-  color: rgba(100, 116, 139, 0.9);
+  letter-spacing: 0.22em;
+  color: rgba(148, 163, 184, 0.7);
 }
 
 .meta-value {
   font-size: 18px;
   font-weight: 600;
-  color: #1f2937;
+  color: #e0f2fe;
 }
 
 .meta-date {
   font-size: 14px;
-  color: rgba(71, 85, 105, 0.85);
+  color: rgba(148, 163, 184, 0.78);
 }
 
 .meta-fy {
@@ -109,18 +112,18 @@ body {
   margin-top: 8px;
   padding: 6px 14px;
   border-radius: 999px;
-  border: 1px solid rgba(239, 68, 68, 0.35);
-  color: #b91c1c;
+  border: 1px solid rgba(56, 189, 248, 0.45);
+  color: #38bdf8;
   font-size: 12px;
   letter-spacing: 0.18em;
-  background: rgba(248, 113, 113, 0.1);
+  background: rgba(8, 145, 178, 0.12);
 }
 
 .panes {
   flex: 1;
   display: grid;
-  grid-template-columns: 1.4fr 0.6fr;
-  gap: 64px;
+  grid-template-columns: 1.45fr 0.55fr;
+  gap: 56px;
   position: relative;
   z-index: 2;
 }
@@ -128,43 +131,32 @@ body {
 .map {
   display: flex;
   flex-direction: column;
-  gap: 28px;
+  gap: 24px;
 }
 
 .map-frame {
   position: relative;
   flex: 1;
-  border-radius: 40px;
+  border-radius: 36px;
   overflow: hidden;
-  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.88));
-  border: 1px solid rgba(148, 163, 184, 0.32);
-  box-shadow: 0 42px 110px rgba(100, 116, 139, 0.28);
-}
-
-.map-frame::before {
-  content: '';
-  position: absolute;
-  inset: 0;
-  background:
-    radial-gradient(circle at 20% 25%, rgba(148, 163, 184, 0.18), transparent 55%),
-    radial-gradient(circle at 80% 78%, rgba(203, 213, 225, 0.22), transparent 60%),
-    radial-gradient(circle at 65% 32%, rgba(59, 130, 246, 0.1), transparent 65%);
-  opacity: 1;
+  background: radial-gradient(circle at 48% 46%, rgba(30, 41, 59, 0.92), rgba(15, 23, 42, 0.88));
+  border: 1px solid rgba(71, 85, 105, 0.55);
+  box-shadow: inset 0 0 45px rgba(2, 6, 23, 0.6);
 }
 
 .map-frame::after {
   content: '';
   position: absolute;
-  inset: 32px;
-  border-radius: 32px;
-  border: 2px dashed rgba(203, 213, 225, 0.65);
+  inset: 24px;
+  border-radius: 28px;
+  border: 1px dashed rgba(51, 65, 85, 0.55);
   pointer-events: none;
 }
 
 .map-overlay {
   position: absolute;
   inset: 0;
-  padding: 80px;
+  padding: 64px;
 }
 
 .center-badge {
@@ -172,42 +164,45 @@ body {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  width: 300px;
-  height: 300px;
+  width: 280px;
+  height: 280px;
   border-radius: 50%;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: radial-gradient(circle at 35% 30%, #1f2937 0%, #111827 68%, #0b1120 100%);
-  border: 10px solid rgba(255, 255, 255, 0.85);
-  box-shadow: 0 40px 60px rgba(15, 23, 42, 0.35);
+  background: radial-gradient(circle at 40% 30%, rgba(8, 145, 178, 0.28), rgba(2, 6, 23, 0.95));
+  border: 8px solid rgba(94, 234, 212, 0.12);
+  box-shadow:
+    0 28px 60px rgba(15, 23, 42, 0.55),
+    inset 0 0 45px rgba(8, 145, 178, 0.22);
   pointer-events: none;
+  text-align: center;
 }
 
 .center-label {
   margin: 0;
   font-size: 30px;
   font-weight: 800;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   color: #f8fafc;
-  text-align: center;
-  text-shadow: 0 10px 24px rgba(15, 23, 42, 0.55);
+  text-shadow: 0 8px 30px rgba(2, 6, 23, 0.8);
+  white-space: pre-line;
 }
 
 .center-sub {
   margin: 12px 0 0;
-  font-size: 15px;
-  letter-spacing: 0.08em;
-  color: rgba(254, 243, 199, 0.9);
+  font-size: 16px;
+  letter-spacing: 0.12em;
+  color: rgba(148, 163, 184, 0.88);
   text-transform: uppercase;
 }
 
 .map-actions {
   display: flex;
-  gap: 16px;
   flex-wrap: wrap;
+  gap: 14px;
 }
 
 .pill {
@@ -215,29 +210,39 @@ body {
   align-items: center;
   justify-content: center;
   gap: 8px;
-  padding: 10px 20px;
+  padding: 10px 22px;
   border-radius: 999px;
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 600;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.16em;
   text-transform: uppercase;
   color: #0f172a;
-  background: linear-gradient(120deg, rgba(251, 191, 36, 0.95), rgba(248, 113, 113, 0.95));
-  border: 1px solid rgba(248, 113, 113, 0.3);
+  background: linear-gradient(130deg, rgba(94, 234, 212, 0.9), rgba(14, 165, 233, 0.9));
+  border: 1px solid rgba(94, 234, 212, 0.32);
   cursor: pointer;
   text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
 }
 
 .pill:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 34px rgba(251, 191, 36, 0.32);
+  box-shadow: 0 18px 38px rgba(14, 165, 233, 0.35);
+  filter: brightness(1.05);
 }
 
 .pill-ghost {
-  background: rgba(14, 165, 233, 0.18);
-  color: #0f172a;
-  border-color: rgba(14, 165, 233, 0.35);
+  background: rgba(30, 41, 59, 0.6);
+  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.45);
+}
+
+.pill-ghost:hover {
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.55);
+  filter: brightness(1.1);
+}
+
+.hidden {
+  display: none !important;
 }
 
 #fileInput {
@@ -251,57 +256,57 @@ body {
 .detail {
   display: flex;
   flex-direction: column;
-  gap: 32px;
-  padding: 36px;
-  border-radius: 32px;
-  background: rgba(255, 255, 255, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  box-shadow: 0 34px 70px rgba(148, 163, 184, 0.26);
+  gap: 28px;
+  padding: 32px;
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.86);
+  border: 1px solid rgba(71, 85, 105, 0.55);
+  box-shadow: inset 0 0 35px rgba(2, 6, 23, 0.72);
 }
 
 .detail-header h2 {
   margin: 0;
-  font-size: 32px;
+  font-size: 30px;
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: #111827;
+  color: #f8fafc;
 }
 
 .detail-amount {
   margin: 12px 0 0;
-  font-size: 28px;
+  font-size: 26px;
   font-weight: 600;
-  color: #b91c1c;
+  color: #5eead4;
 }
 
 .detail-share {
   margin: 8px 0 0;
-  font-size: 14px;
+  font-size: 13px;
   text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: rgba(71, 85, 105, 0.9);
+  letter-spacing: 0.12em;
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .detail-path {
   margin: 12px 0 0;
   font-size: 13px;
-  letter-spacing: 0.04em;
-  color: rgba(100, 116, 139, 0.75);
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.66);
 }
 
 .detail-desc {
   margin: 18px 0 0;
   font-size: 15px;
   line-height: 1.6;
-  color: rgba(30, 41, 59, 0.85);
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .detail-body h3 {
   margin: 0 0 12px;
-  font-size: 16px;
+  font-size: 15px;
   text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: rgba(71, 85, 105, 0.85);
+  letter-spacing: 0.14em;
+  color: rgba(148, 163, 184, 0.75);
 }
 
 .children {
@@ -310,7 +315,7 @@ body {
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
   max-height: 420px;
   overflow-y: auto;
 }
@@ -318,41 +323,39 @@ body {
 .children li {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
   padding: 14px 18px;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid rgba(226, 232, 240, 0.9);
-  box-shadow: 0 12px 26px rgba(148, 163, 184, 0.22);
+  background: rgba(30, 41, 59, 0.72);
+  border: 1px solid rgba(71, 85, 105, 0.6);
+  box-shadow: inset 0 0 14px rgba(2, 6, 23, 0.65);
 }
 
 .children li .name {
   font-size: 15px;
   font-weight: 600;
-  color: #1f2937;
+  color: #f8fafc;
 }
 
 .children li .amount {
-  font-size: 14px;
-  color: rgba(71, 85, 105, 0.85);
+  font-size: 13px;
+  color: rgba(148, 163, 184, 0.78);
 }
 
 .children li.empty {
   justify-content: center;
-  color: rgba(148, 163, 184, 0.85);
+  color: rgba(148, 163, 184, 0.6);
   font-style: italic;
 }
 
-@media (max-width: 1980px) {
+@media (max-width: 1680px) {
   body {
     padding: 24px;
   }
 
   .canvas {
-    width: min(1980px, 100%);
-    height: auto;
-    min-height: 900px;
+    padding: 40px;
   }
 
   .panes {
@@ -364,12 +367,11 @@ body {
   }
 
   .map-overlay {
-    padding: 48px;
+    padding: 40px;
   }
 
   .center-badge {
     width: 240px;
     height: 240px;
-    border-width: 8px;
   }
 }

--- a/index.html
+++ b/index.html
@@ -42,6 +42,7 @@
           </div>
         </div>
         <div class="map-actions">
+          <button id="backBtn" class="pill pill-ghost hidden">Back to National Budget</button>
           <label for="fileInput" class="pill">Upload JSON</label>
           <a class="pill" href="data/th_budget_FY2025.json" download>Download Data</a>
           <button id="dlPngBtn" class="pill">Export PNG</button>


### PR DESCRIPTION
## Summary
- rebuild the ECharts mindmap so ministries animate into the center with breadcrumb navigation and a dedicated back button
- parse and surface budget totals and parent shares in the center badge, tooltip, and detail panel
- restyle the interface with a dark theme that highlights the interactive budget nodes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68deacb6318c8329b872eb424995085b